### PR TITLE
Replace math/rand with crypto/rand

### DIFF
--- a/frame_test.go
+++ b/frame_test.go
@@ -2,7 +2,7 @@ package hdlc
 
 import (
 	"bytes"
-	"math/rand"
+	"crypto/rand"
 	"reflect"
 	"strings"
 	"testing"


### PR DESCRIPTION
From staticcheck: math/rand.Read has been deprecated since Go 1.20 because it shouldn't be used: For almost all use cases, crypto/rand.Read is more appropriate. (SA1019)

- https://staticcheck.dev/docs/checks/#SA1019
- https://pkg.go.dev/math/rand#Read