### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.20.5
+
+      - name: Install staticcheck
+        run: go install honnef.co/go/tools/cmd/staticcheck@2023.1.3
+
+      - name: Lint
+        run: staticcheck -checks=all ./...
+
+      - name: Test
+        run: go test -v ./...

--- a/frame_test.go
+++ b/frame_test.go
@@ -2,7 +2,7 @@ package hdlc
 
 import (
 	"bytes"
-	"math/rand"
+	"crypto/rand"
 	"reflect"
 	"strings"
 	"testing"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/zaninime/go-hdlc
 
-go 1.12
+go 1.20
 
 require (
 	github.com/sigurn/crc16 v0.0.0-20160107003519-da416fad5162

--- a/hdlc.go
+++ b/hdlc.go
@@ -1,0 +1,3 @@
+// Package hdlc provides a simple implementation of an Encoder/Decoder for the
+// High-Level Data Link Control as used in the PPP (Point-to-Point Protocol).
+package hdlc


### PR DESCRIPTION
With the addition of this workflow, the following code changes were made:

- Replace math/rand with crypto/rand

    From staticcheck: math/rand.Read has been deprecated since Go 1.20
    because it shouldn't be used: For almost all use cases,
    crypto/rand.Read is more appropriate. (SA1019)

- Add documentation comment to package

    From staticcheck: at least one file in a package should have a
    package comment (ST1000)